### PR TITLE
Cleanup binding.cc & fix memory/handle leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function createDirectoryStream (name) {
   }
 
   function openAndRead (cb) {
-    stream.struct = Buffer.alloc(binding.SIZEOF_FS_DIRECTORY_STREAM_T)
+    stream.struct = binding.make_uv_fs_scandir_buffer()
     binding.uv_fs_scandir(stream.struct, stream.name, function (err) {
       if (err) return cb(err)
       read(cb)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "tape": "^4.8.0"
   },
   "scripts": {
-    "test": "standard && tape test.js"
+    "test": "standard && node --expose-gc test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -34,3 +34,15 @@ tape('ENOTDIR', function (t) {
     })
     .resume()
 })
+
+tape('running GC after creating a stream works fine', function (t) {
+  createDirectoryStream(__dirname)
+    .on('data', function dummy () {})
+    .on('end', function () {
+      setTimeout(function () {
+        global.gc()
+        global.gc(true)
+        t.end()
+      }, 10)
+    })
+})


### PR DESCRIPTION
- Call `uv_fs_req_cleanup()` when `fs_directory_stream_t` is GC’ed
- Make sure the `fs_directory_stream_t` destructor, and in particular
  `Nan::Callback::~Callback` is run then the struct is GC’ed
- Reset the callback after it has been called, since otherwise it is
  considered a GC root and anything the closure refers to, including the
  `fs_directory_stream_t`, would be retained indefinitely
- Add a test for GC & make it run as part of the default build
- Remove a redundant `EscapableHandleScope`
- Remove a redundant cast